### PR TITLE
Enable Doppler Service Token to be passed as a parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,11 @@
 ## 0.0.3 (April 27, 2022)
 
 - Added `user-agent` header to Doppler provider
+
+## 0.0.4 (May 25, 2022)
+
+- Improved README
+
+## 0.0.5 (May 25, 2022)
+
+- Enable Doppler Service Token to be passed as a parameter to the Doppler provider

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "gitops-secrets",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "author": "Ryan Blunden <ryan.blunden@doppler.com>",
-  "description": "Securely bundle encrypted secrets into your deployments and safely decrypt at runtime.",
+  "description": "SecretOps workflow for bundling encrypted secrets into your deployments to safely decrypt at runtime.",
   "repository": {
     "type": "git",
     "url": "https://github.com/DopplerHQ/gitops-secrets-nodejs.git"

--- a/src/providers/doppler.js
+++ b/src/providers/doppler.js
@@ -1,17 +1,18 @@
 const https = require("https");
 const { VERSION } = require("../meta");
+
 /**
  * Fetch secrets from Doppler the API.
- * Requires the `DOPPLER_TOKEN` environment variable to be set. See https://docs.doppler.com/docs/enclave-service-tokens
+ * @param {{dopplerToken: string}} [{dopplerToken: process.env.DOPPLER_TOKEN}] Requires a Doppler Service Token for API authentication. See https://docs.doppler.com/docs/enclave-service-tokens
  * @returns {() => Promise<Record<string, string>>}
  */
-async function fetch() {
-  if (!process.env.DOPPLER_TOKEN) {
+async function fetch({ dopplerToken = process.env.DOPPLER_TOKEN } = {}) {
+  if (!dopplerToken) {
     throw new Error("Doppler API Error: The 'DOPPLER_TOKEN' environment variable is required");
   }
 
   return new Promise(function (resolve, reject) {
-    const encodedAuthData = Buffer.from(`${process.env.DOPPLER_TOKEN}:`).toString("base64");
+    const encodedAuthData = Buffer.from(`${dopplerToken}:`).toString("base64");
     const authHeader = `Basic ${encodedAuthData}`;
     const userAgent = `gitops-secrets-nodejs/${VERSION}`;
     https

--- a/tests/providers.doppler.test.js
+++ b/tests/providers.doppler.test.js
@@ -9,16 +9,25 @@ if (!process.env.DOPPLER_TOKEN) {
 const DOPPLER_TOKEN = process.env.DOPPLER_TOKEN;
 beforeEach(() => (process.env.DOPPLER_TOKEN = DOPPLER_TOKEN));
 
-test("fetch fails without DOPPLER_TOKEN", async () => {
+test("fetch fails if DOPPLER_TOKEN environment variable and dopplerToken param are null", async () => {
   delete process.env.DOPPLER_TOKEN;
   await expect(doppler.fetch()).rejects.toThrowError("Doppler API Error");
 });
 
-test("fetch fails with invalid DOPPLER_TOKEN", async () => {
+test("fetch fails with invalid DOPPLER_TOKEN environment variable", async () => {
   process.env.DOPPLER_TOKEN = "XXXX";
   await expect(doppler.fetch()).rejects.toThrowError();
 });
 
-test("fetch succeeds with DOPPLER_TOKEN", async () => {
+test("fetch fails with invalid dopplerToken param", async () => {
+  await expect(doppler.fetch({ dopplerToken: "XXXX" })).rejects.toThrowError();
+});
+
+test("fetch succeeds with DOPPLER_TOKEN environment variable", async () => {
   await expect(doppler.fetch()).resolves.toHaveProperty("DOPPLER_PROJECT");
+});
+
+test("fetch succeeds with valid dopplerToken param", async () => {
+  delete process.env.DOPPLER_TOKEN;
+  await expect(doppler.fetch({ dopplerToken: DOPPLER_TOKEN })).resolves.toHaveProperty("DOPPLER_PROJECT");
 });

--- a/tests/secrets.test.js
+++ b/tests/secrets.test.js
@@ -8,7 +8,7 @@ const read = (file) => fs.readFileSync(path.resolve(file), { encoding: "utf8" })
 // eslint-disable-next-line security/detect-non-literal-fs-filename
 const rm = (...files) => files.forEach((file) => fs.unlinkSync(path.resolve(file)));
 
-const PROCESS_ENV = Object.assign({}, process.env);
+const PROCESS_ENV = { ...process.env };
 const NPM_PACKAGE_TYPE = process.env.npm_package_type;
 
 const GITOPS_SECRETS_MASTER_KEY = "1e18cc54-1d77-45a1-ae46-fecebce35ae2";

--- a/tests/secrets.test.js
+++ b/tests/secrets.test.js
@@ -8,7 +8,7 @@ const read = (file) => fs.readFileSync(path.resolve(file), { encoding: "utf8" })
 // eslint-disable-next-line security/detect-non-literal-fs-filename
 const rm = (...files) => files.forEach((file) => fs.unlinkSync(path.resolve(file)));
 
-const PROCESS_ENV = process.env;
+const PROCESS_ENV = Object.assign({}, process.env);
 const NPM_PACKAGE_TYPE = process.env.npm_package_type;
 
 const GITOPS_SECRETS_MASTER_KEY = "1e18cc54-1d77-45a1-ae46-fecebce35ae2";


### PR DESCRIPTION
Being able to pass the Service token in as a parameter provides a cleaner solution for instances such as the [Doppler Pipedream application](https://pipedream.com/apps/doppler-secretops) where the service token can be securely injected by their platform, eliminating the need to redefine the `DOPPLER_TOKEN` environment variable.

This should be merged after the #27 