### PR TITLE
Update Doppler provider to accept Project and Config params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@
 ## 0.0.5 (May 25, 2022)
 
 - Enable Doppler Service Token to be passed as a parameter to the Doppler provider
+
+## 0.0.6 (July 25, 2023)
+
+- Enable Doppler Project and Doppler Config to be passed as a parameter to the Doppler provider

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitops-secrets",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": "Ryan Blunden <ryan.blunden@doppler.com>",
   "description": "SecretOps workflow for bundling encrypted secrets into your deployments to safely decrypt at runtime.",
   "repository": {

--- a/src/providers/doppler.js
+++ b/src/providers/doppler.js
@@ -1,12 +1,15 @@
 const https = require("https");
+const querystring = require("querystring");
 const { VERSION } = require("../meta");
 
 /**
  * Fetch secrets from Doppler the API.
- * @param {{dopplerToken: string}} [{dopplerToken: process.env.DOPPLER_TOKEN}] Requires a Doppler Service Token for API authentication. See https://docs.doppler.com/docs/enclave-service-tokens
+ * @param {{dopplerToken: string}} [{dopplerToken: process.env.DOPPLER_TOKEN}] Requires a Doppler Token for API authentication. See https://docs.doppler.com/docs/enclave-service-tokens
+ * @param {{dopplerProject: string}} [{dopplerProject: null}] Optional Doppler Project. Required when using any token type other than Service Tokens.
+ * @param {{dopplerConfig: string}} [{dopplerConfig: null}] Optional Doppler Config. Required when using any token type other than Service Tokens.
  * @returns {() => Promise<Record<string, string>>}
  */
-async function fetch({ dopplerToken = process.env.DOPPLER_TOKEN } = {}) {
+async function fetch({ dopplerToken = process.env.DOPPLER_TOKEN, dopplerProject = null, dopplerConfig = null } = {}) {
   if (!dopplerToken) {
     throw new Error("Doppler API Error: The 'DOPPLER_TOKEN' environment variable is required");
   }
@@ -14,9 +17,10 @@ async function fetch({ dopplerToken = process.env.DOPPLER_TOKEN } = {}) {
   return new Promise(function (resolve, reject) {
     const authHeader = `Bearer ${dopplerToken}`;
     const userAgent = `gitops-secrets-nodejs/${VERSION}`;
+    const query = { format: "json", project: dopplerProject, config: dopplerConfig };
     https
       .get(
-        "https://api.doppler.com/v3/configs/config/secrets/download?format=json",
+        `https://api.doppler.com/v3/configs/config/secrets/download?${querystring.stringify(query)}`,
         {
           headers: {
             Authorization: authHeader,

--- a/src/providers/doppler.js
+++ b/src/providers/doppler.js
@@ -12,8 +12,7 @@ async function fetch({ dopplerToken = process.env.DOPPLER_TOKEN } = {}) {
   }
 
   return new Promise(function (resolve, reject) {
-    const encodedAuthData = Buffer.from(`${dopplerToken}:`).toString("base64");
-    const authHeader = `Basic ${encodedAuthData}`;
+    const authHeader = `Bearer ${dopplerToken}`;
     const userAgent = `gitops-secrets-nodejs/${VERSION}`;
     https
       .get(


### PR DESCRIPTION
Updates the Doppler provider to accept a Project and Config parameter. The previous usage remains unchanged (i.e., if you use a Service Token where the project and config can be inferred), but if you use any token type other than a Service Token without providing a project and config param, you'll get an error now.

```js
const secrets = require("gitops-secrets");

async function main() {
  const payload = await secrets.providers.doppler.fetch({ dopplerProject: "example", dopplerConfig: "dev");
}
```

This will allow for [Service Account tokens](https://docs.doppler.com/docs/service-accounts) to be used.

Fixes #39.